### PR TITLE
Removed `function_replacement_data_v2_t`.

### DIFF
--- a/include/function_patcher/fpatching_defines.h
+++ b/include/function_patcher/fpatching_defines.h
@@ -122,17 +122,6 @@ typedef enum FunctionPatcherTargetProcess {
 typedef uint32_t PatchedFunctionHandle;
 #define FUNCTION_REPLACEMENT_DATA_STRUCT_VERSION 0x00000003
 
-typedef struct function_replacement_data_v2_t {
-    uint32_t VERSION;
-    uint32_t physicalAddr;                       /* [needs to be filled]  */
-    uint32_t virtualAddr;                        /* [needs to be filled]  */
-    uint32_t replaceAddr;                        /* [needs to be filled] Address of our replacement function */
-    uint32_t *replaceCall;                       /* [needs to be filled] Address to access the real_function */
-    function_replacement_library_type_t library; /* [needs to be filled] rpl where the function we want to replace is. */
-    const char *function_name;                   /* [needs to be filled] name of the function we want to replace */
-    FunctionPatcherTargetProcess targetProcess;  /* [will be filled] */
-} function_replacement_data_v2_t;
-
 typedef struct function_replacement_data_t {
     uint32_t version;
     FunctionPatcherFunctionType type;


### PR DESCRIPTION
This removes the legacy type to avoid clashes with the `VERSION` identifier.

The corresponding PR that adds it as a private type to the FunctionPatcherModule is this: https://github.com/wiiu-env/FunctionPatcherModule/pull/33